### PR TITLE
change single quotation marks to double for windows compatability

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "private": true,
   "author": "Onur Elibol",
   "scripts": {
-    "serve": "concurrently 'npm run dev:server' 'npm run dev:client' --raw",
-    "build": "concurrently 'npm run build:server' 'npm run build:client'",
+    "serve": "concurrently \"npm run dev:server\" \"npm run dev:client\" --raw",
+    "build": "concurrently \"npm run build:server\" \"npm run build:client\"",
     "dev:client": "vue-cli-service serve",
     "build:client": "vue-cli-service build",
     "dev:server": "nodemon --config ./nodemon.config.json",


### PR DESCRIPTION
I tried running your project on windows, but it get's confused with the single quotation marks and tries to run `'npm` and `run` etc.
which obv. does not work. So i changed it and provide this now to try on mac / linux then to be merged if compatible with all platforms.